### PR TITLE
added configuration options for the ts compiler 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
   "name": "analysis-dashboard",
-  "private": true,
-  "version": "0.0.0",
-  "type": "module",
+  "version": "1.0.0",
+  "source": "index.html",
+  "browserslist": "> 0.5%, last 2 versions, not dead",
   "scripts": {
-    "dev": "vite",
-    "build": "tsc && vite build",
-    "preview": "vite preview"
+    "start": "vite",
+    "build": "tsc --noEmit && vite build",
+    "preview": "vite preview",
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "author": "Africa's Voices Foundation",
+  "license": "MIT",
   "devDependencies": {
-    "typescript": "^5.0.2",
+    "typescript": "^5.0.4",
     "vite": "^4.3.2"
-  },
-  "dependencies": {
-    "echarts": "^5.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "analysis-dashboard",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.2",
+    "vite": "^4.3.2"
+  },
+  "dependencies": {
+    "echarts": "^5.4.2"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "target": "ES2015",
+    "useDefineForClassFields": true,
+    "module": "es6",
+    "lib": ["ES2015", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "esModuleInterop": true, 
+    "forceConsistentCasingInFileNames": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+ 
+    /* Linting */
+    "strict": true,
+    "alwaysStrict": true,
+    "strictFunctionTypes":true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "useUnknownInCatchVariables": true,
+    "strictPropertyInitialization": true,
+    "noImplicitOverride": true,
+   
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
also updated the dev flag under scripts in package.json to enable the ts compiler to compile ts files in developer mode since vite only supports ts compilation  in production mode.