### PR TITLE
Update tsconfig flags

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig to read more about this file */
-    "target": "es2016",                                 /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "moduleResolution": "node10",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    /* Visit https://aka.ms/tsconfig to read more about this file
+     *
+     * This file follows the advice in https://vitejs.dev/guide/features.html#typescript, and also enables the strictest
+     * type-checking flags.
+     */
+
+    "target": "es6",                                 /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "moduleResolution": "bundler",                   /* Specify how TypeScript looks up a file from a given module specifier. */
+    "useDefineForClassFields": true,                 /* Emit ECMAScript-standard-compliant class fields. */
+    "isolatedModules": true,                         /* Ensure that each file can be safely transpiled without relying on other imports. */
 
     /* Interop Constraints */
     "esModuleInterop": true,                          /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
@@ -26,5 +33,7 @@
     "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
     "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
     "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+
+    "skipLibCheck": true                              /* Skip type checking all .d.ts files. */
   }
 }


### PR DESCRIPTION
- Follows Vite recommendations for using tsconfig as a type-checker only.
- Skips lib check, so we can use libraries with less-strict type checking.

Thanks to @elvinmworia for the suggestions in #2 and #4 which have been incorporated here.