### PR TITLE
Create a single RulesTestEnvironment per test suite

### DIFF
--- a/tests/database/Database.test.ts
+++ b/tests/database/Database.test.ts
@@ -17,7 +17,6 @@ import SeriesUser, {
     userConvertor,
 } from "../../src/database/models/SeriesUser";
 import Database from "../../src/database/Database";
-import fs from "fs";
 import AnalysisSnapshot, {
     analysisSnapshotConverter,
     AnalysisSnapshotTag,

--- a/tests/database/Database.test.ts
+++ b/tests/database/Database.test.ts
@@ -4,6 +4,7 @@ import {
     assertSucceeds,
     initializeTestEnvironment,
     RulesTestContext,
+    RulesTestEnvironment,
 } from "@firebase/rules-unit-testing";
 import {
     doc,
@@ -70,16 +71,23 @@ async function writeTestDataToFirestore(firestore: Firestore): Promise<void> {
     );
 }
 
+let testEnv: RulesTestEnvironment;
+async function setUpDatabase() {
+    testEnv = await initializeTestEnvironment({
+        projectId: "avf-dashboards-test",
+        firestore: {},
+    });
+
+    await testEnv.clearFirestore();
+
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+        await writeTestDataToFirestore(context.firestore());
+    });
+}
+
 async function getUserContext(
     userEmail: string | null
 ): Promise<RulesTestContext> {
-    const testEnv = await initializeTestEnvironment({
-        projectId: "avf-dashboards-test",
-        firestore: {
-            rules: fs.readFileSync("firestore.rules", "utf8"),
-        },
-    });
-
     if (userEmail === null) {
         return testEnv.unauthenticatedContext();
     }
@@ -96,26 +104,6 @@ async function getDatabaseForUser(userEmail: string | null): Promise<Database> {
     // type. Both types are compatible with each other, just defined in different places.
     const firestore: Firestore = userContext.firestore();
     return new Database(firestore);
-}
-
-async function setUpDatabase() {
-    const testEnv = await initializeTestEnvironment({
-        projectId: "avf-dashboards-test",
-        firestore: {
-            // Allow global access to everything for now, so we can initialise the database
-            rules:
-                "service cloud.firestore { match /databases/{database}/documents { match /{document=**} { " +
-                "allow read, write: if true;" +
-                "}}}",
-        },
-    });
-
-    await testEnv.clearFirestore();
-
-    const admin = testEnv.unauthenticatedContext();
-    // @ts-ignore because admin.firestore() returns the Firebase v8 type but Database expects the v9
-    // type. Both types are compatible with each other, just defined in different places.
-    await writeTestDataToFirestore(admin.firestore());
 }
 
 describe.concurrent("Test Database", () => {

--- a/tests/firebase-emulator-connection-tests/storage-emulator-connection.test.ts
+++ b/tests/firebase-emulator-connection-tests/storage-emulator-connection.test.ts
@@ -1,48 +1,40 @@
-import {
-    ref,
-    uploadString,
-    getDownloadURL,
-    StorageReference,
-} from "firebase/storage";
+import { ref, uploadString, getDownloadURL } from "firebase/storage";
 import fetch from "node-fetch";
 import { expect, test, describe, beforeAll } from "vitest";
 import {
     assertSucceeds,
     initializeTestEnvironment,
+    RulesTestEnvironment,
 } from "@firebase/rules-unit-testing";
 
 describe("Test the connection to the Firebase Storage emulator is working", async () => {
-    let testRef: StorageReference;
+    let testEnv: RulesTestEnvironment;
     beforeAll(async () => {
-        let testEnv = await initializeTestEnvironment({
+        testEnv = await initializeTestEnvironment({
             projectId: "avf-dashboards-test",
-            storage: {
-                // Allow global access to everything for now, so we can initialise the database
-                rules:
-                    "rules_version = '2';" +
-                    "service firebase.storage { match /b/{bucket}/o { match /{allPaths=**} {" +
-                    "    allow read, write: if true;" +
-                    "}}}",
-            },
+            storage: {},
         });
 
         // Reset the emulator in case it was used for any previous tests
         await testEnv.clearStorage();
-
-        const admin = testEnv.unauthenticatedContext();
-        testRef = ref(admin.storage(), "test.txt");
     });
 
     const message = "Test message";
 
     test("Can write a test blob to the Firebase Storage emulator", async () => {
-        await assertSucceeds(uploadString(testRef, message));
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+            const testRef = ref(context.storage(), "test.txt");
+            await assertSucceeds(uploadString(testRef, message));
+        });
     });
 
     test("Can read the uploaded test blob from the Firebase Storage emulator", async () => {
-        const url = await getDownloadURL(testRef);
-        const response = await fetch(url);
-        const downloadedText = await response.text();
-        expect(message).toStrictEqual(downloadedText);
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+            const testRef = ref(context.storage(), "test.txt");
+            const url = await getDownloadURL(testRef);
+            const response = await fetch(url);
+            const downloadedText = await response.text();
+            expect(message).toStrictEqual(downloadedText);
+        });
     });
 });


### PR DESCRIPTION
This improves test performance and reliability with the Storage emulator.

It also uses "withSecurityRulesDisabled" instead of special admin rules + unauthenticated admin users, so it should be clearer which code is being run with the rules enabled/disabled.